### PR TITLE
Fix Next.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/react-dom": "^19.1.6",
         "framer-motion": "^12.16.0",
         "lucide-react": "^0.513.0",
-        "next.js": "^1.0.3",
+        "next": "^14.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tailwindcss": "^4.1.8",
@@ -7077,10 +7077,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/next.js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/next.js/-/next.js-1.0.3.tgz",
-      "integrity": "sha512-nosnT7Jh4ML3kzwG9MPW+SfBKuHoZEMcCWw5kxwMYXoxnADGzIxWl+TdDMcEZP6Xl/t8m/5uyVlA9SBkH2oh/w=="
+    "node_modules/next": {
+      "version": "14.2.0",
+      "resolved": "",
+      "integrity": ""
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/react-dom": "^19.1.6",
     "framer-motion": "^12.16.0",
     "lucide-react": "^0.513.0",
-    "next.js": "^1.0.3",
+    "next": "^14.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^4.1.8",


### PR DESCRIPTION
## Summary
- replace invalid `next.js` package with proper `next` dependency

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: no tests specified)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68455f3e73a0832190021e24e23eb3cc